### PR TITLE
Fix remastered models not being used in Dissolution of Eternity

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2130,6 +2130,7 @@ _add_path:
 	search = (searchpath_t *)Mem_Alloc (sizeof (searchpath_t));
 	search->path_id = path_id;
 	q_strlcpy (search->filename, com_gamedir, sizeof (search->filename));
+	q_strlcpy (search->dir, dir, sizeof (search->dir));
 	search->next = com_searchpaths;
 	com_searchpaths = search;
 
@@ -2145,6 +2146,7 @@ _add_path:
 			search = (searchpath_t *)Mem_Alloc (sizeof (searchpath_t));
 			search->path_id = path_id;
 			search->pack = pak;
+			q_strlcpy (search->dir, dir, sizeof (search->dir));
 			search->next = com_searchpaths;
 			com_searchpaths = search;
 		}
@@ -2168,6 +2170,7 @@ _add_path:
 			search = (searchpath_t *)Mem_Alloc (sizeof (searchpath_t));
 			search->path_id = path_id;
 			search->pack = pak;
+			q_strlcpy (search->dir, dir, sizeof (search->dir));
 			search->next = com_searchpaths;
 			com_searchpaths = search;
 			com_modified = pak0_modified;

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -334,7 +334,8 @@ typedef struct searchpath_s
 								  // Note that <install_dir>/game1 and
 								  // <userdir>/game1 have the same id.
 	char				 filename[MAX_OSPATH];
-	pack_t				*pack; // only one of filename / pack will be used
+	pack_t				*pack;			 // only one of filename / pack will be used
+	char				 dir[MAX_QPATH]; // directory name: "id1", "rogue", etc.
 	struct searchpath_s *next;
 } searchpath_t;
 


### PR DESCRIPTION
In vkQuake when playing Dissolution of Eternity (rogue) with the rerelease, the remastered MD5 models are not used for the hell knight, knight, ogre, player, spawn, or zombie. Kex Quake correctly uses the remastered models when possible with DoE. This PR fixes this and makes vkQuake consistent with Kex Quake.

Background:
- DoE adds enemy variants like the multi-grenade ogre and statue knights which have their own skins which don't exist with the remastered MD5 models. DoE provides its own MDL models for ogre/knight/etc which are identical to the original MDLs except with some extra skins added.
- vkQuake with r_md5models=1 (default setting) ignores the corresponding MD5 models for any MDL file that are provided at a later search path than the MDL. This setting works great for many mods that customize the appearance of enemies by providing a new MDL model, preventing the built-in remastered MD5 models from replacing the mod's customized models. However, it causes DoE's MDLs to take total priority over the remastered MD5 models.
- vkQuake with r_md5models=2 ignores the above search path logic about MD5 models and instead uses MD5 models whenever possible except when the entity is using a skin the MD5 model does not have. This setting works great for DoE but not with other mods.

This patch does two things:
1) The search path logic used with r_md5models=1 now special-cases MDL files loaded from DoE so that MD5 models loaded from anywhere (like later search paths like id1) can be used with them.
2) r_md5models=1 now incorporates r_md5models=2's behavior of ignoring MD5 models for entities using skins that don't exist on them. This fixes the issue after step 1 where multi-grenade ogres, statue knights, etc would appear like normal monsters with the remastered models instead of using the custom skin on the DoE MDL. This logic seems desirable in general and is not special-cased to DoE, though I don't believe it affects any other official levels or popular mods.

---

Fixing this in part by adding a special-case for DoE models is a little unsatisfying, but I think it's worth it to be consistent with Kex Quake on official content. A generic solution would probably be overkill (I guess you could try to detect if an MDL is a superset of the original MDL's skins), there already are special-cases in vkQuake for DoE and Scourge of Armagon anyway (for hud stuff), there's no indication Kex Quake isn't doing a similar special-case, there don't seem to be popular mods that run into this exact issue, and future mods could avoid this issue by naming their MDL differently from the original one and only using it for the new enemy variants.